### PR TITLE
fix: correcting i18n import from next instead of react

### DIFF
--- a/components/EmailSection.tsx
+++ b/components/EmailSection.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import emailjs from "@emailjs/browser";
 import { FaHandshake, FaArrowDown } from "react-icons/fa";
 

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -7,7 +7,7 @@ import {
 } from "@heroicons/react/20/solid";
 import { PresentationChartLineIcon } from "@heroicons/react/24/outline";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 const Services = () => {
   const { t } = useTranslation();

--- a/components/about_section/About.tsx
+++ b/components/about_section/About.tsx
@@ -1,5 +1,5 @@
 import { useTransition, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import Image from "next/image";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import { CodeBracketIcon, CubeIcon, CogIcon, AcademicCapIcon, CheckBadgeIcon } from "@heroicons/react/24/solid";

--- a/components/experience_section/ExperienceSection.tsx
+++ b/components/experience_section/ExperienceSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import ExperienceItem from "./ExperienceItem";
 
 const ExperienceSection: React.FC = () => {

--- a/components/hero_section/Hero.tsx
+++ b/components/hero_section/Hero.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import TextEffect from "./TextEffect";
 import Image from "next/image";
 import { ArrowDownTrayIcon, PlayCircleIcon } from "@heroicons/react/20/solid";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import parse from "html-react-parser";
 
 const Hero = () => {

--- a/components/hero_section/TextEffect.tsx
+++ b/components/hero_section/TextEffect.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { TypeAnimation } from "react-type-animation";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 const TextEffect: React.FC = () => {
   const { t } = useTranslation();

--- a/components/main_layout/Footer.tsx
+++ b/components/main_layout/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FaLinkedin, FaGithub, FaInstagram } from "react-icons/fa";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 const Footer: React.FC = () => {
   const { t } = useTranslation();

--- a/components/main_layout/LanguageDropDown.tsx
+++ b/components/main_layout/LanguageDropDown.tsx
@@ -1,6 +1,6 @@
 import { GlobeAltIcon } from "@heroicons/react/24/outline";
 import React, { useState, useEffect, useRef } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 const LanguageDropdown: React.FC = () => {
   const { i18n } = useTranslation();

--- a/components/main_layout/MobileNav.tsx
+++ b/components/main_layout/MobileNav.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import ThemeToggle from "./ThemeToggle";
 import LanguageDropdown from "./LanguageDropDown";
 

--- a/components/main_layout/Nav.tsx
+++ b/components/main_layout/Nav.tsx
@@ -2,7 +2,7 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/20/solid";
 import React, { useState, useEffect } from "react";
 import ThemeToggle from "./ThemeToggle";
 import LanguageDropdown from "./LanguageDropDown";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 interface Props {
   nav: boolean;

--- a/components/projects_section/ImageGallery.tsx
+++ b/components/projects_section/ImageGallery.tsx
@@ -7,7 +7,7 @@ import {
   PhotoIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 interface ImageGalleryProps {
   images: string[];

--- a/components/projects_section/ProjectCard.tsx
+++ b/components/projects_section/ProjectCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { ChevronRightIcon, PhotoIcon } from "@heroicons/react/24/outline";
 import ProjectModal from "./ProjectModal";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import Image from "next/image";
 
 interface ProjectCardProps {

--- a/components/projects_section/ProjectModal.tsx
+++ b/components/projects_section/ProjectModal.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { overlayVariants, modalVariants } from "../../utils/animations";
 import { XMarkIcon, EyeIcon, CodeBracketIcon } from "@heroicons/react/24/outline";
 import ImageGallery from "./ImageGallery";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 interface ProjectModalProps {
   isOpen: boolean;

--- a/components/projects_section/ProjectSkeleton.tsx
+++ b/components/projects_section/ProjectSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 
 const ProjectsSkeleton = () => {
   const { t } = useTranslation();

--- a/components/projects_section/Projects.tsx
+++ b/components/projects_section/Projects.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'next-i18next';
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
 import AnimatedProjectCard from "./AnimatedProjectCard";
 import ProjectTag from "./ProjectTag";


### PR DESCRIPTION
Fixed the hydration bug of text mismatch by switching the i18n import from React to Next.js across all components.